### PR TITLE
refactor(workspace): standardize folder handling and membership checks

### DIFF
--- a/src/features/workspace-article/workspace-article.service.ts
+++ b/src/features/workspace-article/workspace-article.service.ts
@@ -38,8 +38,8 @@ export const WorkspaceArticleService = {
     async findByFolder(folderId: string, query: { page?: number; limit?: number; title?: string }) {
         appAssert(Types.ObjectId.isValid(folderId), BAD_REQUEST, "Nieprawidłowy identyfikator folderu");
 
-        const folder = await WorkspaceFolderModel.findById(folderId).lean();
-        appAssert(folder, NOT_FOUND, "Folder nie istnieje");
+        const folderExists = await WorkspaceFolderModel.exists({ _id: folderId });
+        appAssert(folderExists, NOT_FOUND, "Folder nie istnieje");
 
         const page = Math.max(Number(query.page) || 1, 1);
         const limit = Math.min(Math.max(Number(query.limit) || 10, 1), 100);
@@ -61,10 +61,7 @@ export const WorkspaceArticleService = {
             WorkspaceArticleModel.countDocuments(filter),
         ]);
 
-        const folderWithCount = { ...folder, articlesCount: total };
-
         return {
-            folder: folderWithCount,
             data: articles,
             pagination: {
                 total,

--- a/src/features/workspace-folder/workspace-folder.controller.ts
+++ b/src/features/workspace-folder/workspace-folder.controller.ts
@@ -15,4 +15,9 @@ export const WorkspaceFolderController = (workspaceFolderService = WorkspaceFold
         const folders = await WorkspaceFolderService.findFolders(userId, workspaceId);
         return res.status(OK).json(folders);
     }),
+    findOneFolder: catchErrors(async ({ userId, body, params }, res) => {
+        const { workspaceId, folderId } = params;
+        const folder = await WorkspaceFolderService.findOneFolder(userId, workspaceId, folderId);
+        return res.status(OK).json(folder);
+    }),
 });

--- a/src/features/workspace-folder/workspace-folder.routes.ts
+++ b/src/features/workspace-folder/workspace-folder.routes.ts
@@ -9,3 +9,4 @@ const workspaceFolderController = WorkspaceFolderController();
 // workspaceFolderRoutes.get("/:workspaceId", workspaceFolderController.find);
 workspaceFolderRoutes.post("/:workspaceId", workspaceFolderController.create);
 workspaceFolderRoutes.get("/:workspaceId/folders", workspaceFolderController.findFolders);
+workspaceFolderRoutes.get("/:workspaceId/folders/:folderId", workspaceFolderController.findOneFolder);

--- a/src/features/workspace-folder/workspace-folder.service.ts
+++ b/src/features/workspace-folder/workspace-folder.service.ts
@@ -1,3 +1,4 @@
+import { Types } from "mongoose";
 import { CONFLICT, FORBIDDEN, NOT_FOUND } from "../../constants/http";
 import appAssert from "../../utils/appAssert";
 import WorkspaceMemberModel from "../workspace-member/workspaceMember.model";
@@ -30,7 +31,42 @@ export const WorkspaceFolderService = {
         const isMember = await WorkspaceMemberModel.exists({ userId, workspaceId });
         appAssert(isMember, FORBIDDEN, "Brak dostępu do tego workspace");
 
-        const folders = await WorkspaceFolderModel.find({ workspaceId }).lean();
+        const folders = await WorkspaceFolderModel.aggregate([
+            { $match: { workspaceId: new Types.ObjectId(workspaceId) } },
+            {
+                $lookup: {
+                    from: "workspacearticles",
+                    localField: "_id",
+                    foreignField: "folderId",
+                    as: "articles",
+                },
+            },
+            {
+                $addFields: {
+                    articlesCount: { $size: "$articles" },
+                },
+            },
+            {
+                $project: { articles: 0, __v: 0 },
+            },
+        ]);
+
         return folders;
+    },
+    async findOneFolder(userId: string, workspaceId: string, folderId: string) {
+        const isMember =
+            (await WorkspaceMemberModel.exists({ userId, workspaceId })) ||
+            (await WorkspaceModel.exists({ _id: workspaceId, owner: userId }));
+        if (!isMember) throw new Error("Brak dostępu do workspace");
+
+        const folder = await WorkspaceFolderModel.findOne({ _id: folderId, workspaceId }, { __v: 0 })
+            .populate({
+                path: "createdBy",
+                select: "name surname email",
+            })
+            .lean();
+        if (!folder) throw new Error("Folder nie istnieje");
+
+        return folder;
     },
 };

--- a/src/features/workspace/workspace.service.ts
+++ b/src/features/workspace/workspace.service.ts
@@ -1,7 +1,6 @@
 import { FORBIDDEN, NOT_FOUND } from "../../constants/http";
 import { WorkspaceRoles } from "../../enums/workspaceRole.enum";
 import appAssert from "../../utils/appAssert";
-import { WorkspaceFolderModel } from "../workspace-folder/workspace-folder.model";
 import WorkspaceMemberModel from "../workspace-member/workspaceMember.model";
 import WorkspaceRoleModel from "../workspace-role/workspace-role.model";
 import { CreateWorkspaceDto } from "./dto/create-workspace.dto";
@@ -48,11 +47,6 @@ export const WorkspaceService = {
         const workspace = await WorkspaceModel.findById(workspaceId).lean();
         appAssert(workspace, NOT_FOUND, "Workspace nie istnieje");
 
-        const folders = await WorkspaceFolderModel.find({ workspaceId }).lean();
-
-        return {
-            ...workspace,
-            folders,
-        };
+        return workspace;
     },
 };


### PR DESCRIPTION
- WorkspaceService.findOne no longer fetches folders, returns only workspace.
- WorkspaceArticleService.findByFolder uses exists() for folder validation and removes folder from response.
- WorkspaceFolderService.findFolders now aggregates articles count and excludes unnecessary fields.
- Added WorkspaceFolderService.findOneFolder to fetch a single folder with creator info.