### PR TITLE
refactor: refactor WorkspaceMember model to use permissions only,

### DIFF
--- a/src/features/workspace-folder/workspace-folder.service.ts
+++ b/src/features/workspace-folder/workspace-folder.service.ts
@@ -90,8 +90,8 @@ export const WorkspaceFolderService = {
 
         const member = await WorkspaceMemberModel.findOne({ userId, workspaceId }).populate("role");
         const isOwner = workspace.owner.toString() === userId;
-        const isAdmin = member?.role?.name === "OWNER";
-        appAssert(isOwner || isAdmin, FORBIDDEN, "Brak uprawnień do edycji folderu");
+
+        appAssert(isOwner, FORBIDDEN, "Brak uprawnień do edycji folderu");
 
         const folder = await WorkspaceFolderModel.findOne({ _id: folderId, workspaceId });
 
@@ -117,8 +117,8 @@ export const WorkspaceFolderService = {
 
         const member = await WorkspaceMemberModel.findOne({ userId, workspaceId }).populate("role");
         const isOwner = workspace.owner.toString() === userId;
-        const isAdmin = member?.role?.name === "OWNER";
-        appAssert(isOwner || isAdmin, FORBIDDEN, "Brak uprawnień do usunięcia folderu");
+
+        appAssert(isOwner, FORBIDDEN, "Brak uprawnień do usunięcia folderu");
 
         const folder = await WorkspaceFolderModel.findOne({ _id: folderId, workspaceId });
         appAssert(folder, NOT_FOUND, "Folder nie istnieje");

--- a/src/features/workspace-member/dto/update-workspace-member-permissions.dto.ts
+++ b/src/features/workspace-member/dto/update-workspace-member-permissions.dto.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const updateWorkspaceMemberPermissionsDto = z.object({
+    permissions: z.record(z.boolean()),
+});
+
+export type UpdateWorkspaceMemberPermissionsDto = z.infer<typeof updateWorkspaceMemberPermissionsDto>;

--- a/src/features/workspace-member/workspace-member.controller.ts
+++ b/src/features/workspace-member/workspace-member.controller.ts
@@ -1,0 +1,20 @@
+import { OK } from "@/constants/http";
+import catchErrors from "@/utils/catchErrors";
+import { objectIdParam } from "../../common/dto/params-id.dto";
+
+import { updateWorkspaceMemberPermissionsDto } from "./dto/update-workspace-member-permissions.dto";
+import { WorkspaceMemberService } from "./workspace-member.service";
+
+export const WorkspaceMemberController = (
+    workspaceMemberService: typeof WorkspaceMemberService = WorkspaceMemberService
+) => ({
+    updatePermissions: catchErrors(async ({ params, body, userId }, res) => {
+        const { memberId } = objectIdParam("memberId").parse(params);
+
+        const payload = updateWorkspaceMemberPermissionsDto.parse(body);
+
+        await workspaceMemberService.updatePermissions(userId, memberId, payload);
+
+        return res.status(OK).json({ message: "Permissions updated" });
+    }),
+});

--- a/src/features/workspace-member/workspace-member.routes.ts
+++ b/src/features/workspace-member/workspace-member.routes.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { WorkspaceMemberController } from "./workspace-member.controller";
+
+export const workspaceMemberRoutes = Router();
+const workspaceMemberController = WorkspaceMemberController();
+
+// prefix: /workspace-members
+
+// PATCH /workspace-members/:memberId/permissions
+workspaceMemberRoutes.patch("/:memberId/permissions", workspaceMemberController.updatePermissions);

--- a/src/features/workspace-member/workspace-member.service.ts
+++ b/src/features/workspace-member/workspace-member.service.ts
@@ -1,0 +1,47 @@
+import { FORBIDDEN, NOT_FOUND } from "../../constants/http";
+import appAssert from "../../utils/appAssert";
+import WorkspaceMemberModel from "../workspace-member/workspaceMember.model";
+import WorkspaceModel from "../workspace/workspace.model";
+import { UpdateWorkspaceMemberPermissionsDto } from "./dto/update-workspace-member-permissions.dto";
+
+export const WorkspaceMemberService = {
+    async updatePermissions(currentUserId: string, memberId: string, payload: UpdateWorkspaceMemberPermissionsDto) {
+        const member = await WorkspaceMemberModel.findById(memberId);
+        appAssert(member, NOT_FOUND, "Workspace member not found");
+
+        const workspace = await WorkspaceModel.findById(member.workspaceId);
+        appAssert(workspace, NOT_FOUND, "Workspace not found");
+
+        const isOwner = workspace.owner.toString() === currentUserId;
+
+        appAssert(isOwner, FORBIDDEN, "You do not have sufficient permissions to perform this action");
+
+        member.permissions = {
+            ...member.permissions,
+            ...payload.permissions,
+        };
+
+        await member.save();
+        return member;
+    },
+
+    async deleteMember(currentUserId: string, memberId: string) {
+        const member = await WorkspaceMemberModel.findById(memberId);
+        appAssert(member, NOT_FOUND, "Workspace member not found");
+
+        const workspace = await WorkspaceModel.findById(member.workspaceId);
+        appAssert(workspace, NOT_FOUND, "Workspace not found");
+
+        const currentUserMember = await WorkspaceMemberModel.findOne({
+            userId: currentUserId,
+            workspaceId: member.workspaceId,
+        }).populate("role");
+
+        const isOwner = workspace.owner.toString() === currentUserId;
+
+        appAssert(isOwner, FORBIDDEN, "You do not have sufficient permissions to perform this action");
+
+        await member.deleteOne();
+        return;
+    },
+};

--- a/src/features/workspace-member/workspaceMember.model.ts
+++ b/src/features/workspace-member/workspaceMember.model.ts
@@ -1,11 +1,9 @@
 import mongoose, { Document, Schema } from "mongoose";
-import { WorkspaceRoleDocument } from "../workspace-role/workspace-role.model";
 
 export interface WorkspaceMemberDocument extends Document {
     userId: mongoose.Types.ObjectId;
     workspaceId: mongoose.Types.ObjectId;
     permissions: {};
-    role: WorkspaceRoleDocument;
     joinedAt: Date;
 }
 
@@ -47,11 +45,7 @@ const memberSchema = new Schema<WorkspaceMemberDocument>(
             type: Object,
             default: defaultPermissions,
         },
-        role: {
-            type: Schema.Types.ObjectId,
-            ref: "WorkspaceRole",
-            required: true,
-        },
+
         joinedAt: {
             type: Date,
             default: Date.now,

--- a/src/features/workspace/dto/workspaceMembers.dto.ts
+++ b/src/features/workspace/dto/workspaceMembers.dto.ts
@@ -4,7 +4,7 @@ export const workspaceMembersDto = (members) => {
         name: m.userId?.name ?? null,
         surname: m.userId?.surname ?? null,
         email: m.userId?.email ?? null,
-        role: m.role?.name ?? null,
+        isOwner: m.isOwner ?? false,
         permissions: m.permissions ?? {
             addFolder: false,
             editFolder: false,

--- a/src/features/workspace/workspace.service.ts
+++ b/src/features/workspace/workspace.service.ts
@@ -1,33 +1,37 @@
 import { CONFLICT, FORBIDDEN, NOT_FOUND } from "../../constants/http";
-import { WorkspaceRoles } from "../../enums/workspaceRole.enum";
 import appAssert from "../../utils/appAssert";
-import WorkspaceMemberModel from "../workspace-member/workspaceMember.model";
+import WorkspaceMemberModel, { WorkspacePermissions } from "../workspace-member/workspaceMember.model";
 import WorkspaceRoleModel from "../workspace-role/workspace-role.model";
 import { CreateWorkspaceDto } from "./dto/create-workspace.dto";
 import WorkspaceModel from "./workspace.model";
 
 export const WorkspaceService = {
     async create(userId: string, payload: CreateWorkspaceDto) {
-        const onwerRole = await WorkspaceRoleModel.findOne({ name: WorkspaceRoles.OWNER });
-
-        if (!onwerRole) {
-            throw new Error("Owner role not found");
-        }
         const workspace = await WorkspaceModel.create({
             ...payload,
             owner: userId,
         });
 
+        const allPermissions: WorkspacePermissions = {
+            addFolder: true,
+            editFolder: true,
+            deleteFolder: true,
+            addArticle: true,
+            editArticle: true,
+            deleteArticle: true,
+            addMember: true,
+            removeMember: true,
+        };
+
         const workspaceMember = new WorkspaceMemberModel({
             userId,
             workspaceId: workspace._id,
-            role: onwerRole._id,
             joinedAt: new Date(),
+            permissions: allPermissions,
         });
 
         await workspaceMember.save();
-        // TODO -- extend User model with currentWorkspace field --
-        // user.currentWorkspace = workspace._id as mongoose.Types.ObjectId;
+
         return workspace;
     },
     async find(userId: string) {
@@ -49,18 +53,21 @@ export const WorkspaceService = {
         return workspace;
     },
     async findMembers(workspaceId: string) {
+        const workspace = await WorkspaceModel.findById(workspaceId).lean();
+        appAssert(workspace, NOT_FOUND, "Workspace nie istnieje");
+
         const members = await WorkspaceMemberModel.find({ workspaceId })
             .populate({
                 path: "userId",
                 select: "name surname email",
             })
-            .populate({
-                path: "role",
-                select: "name",
-            })
+
             .lean();
 
-        return members;
+        return members.map((member) => ({
+            ...member,
+            isOwner: member.userId._id.toString() === workspace.owner.toString(),
+        }));
     },
     async updateOne(userId: string, workspaceId: string, payload: CreateWorkspaceDto) {
         const workspace = await WorkspaceModel.findById(workspaceId);
@@ -69,9 +76,8 @@ export const WorkspaceService = {
         const member = await WorkspaceMemberModel.findOne({ userId, workspaceId }).populate("role");
 
         const isOwner = workspace.owner.toString() === userId;
-        const isAdmin = member?.role?.name === WorkspaceRoles.OWNER;
 
-        appAssert(isOwner || isAdmin, FORBIDDEN, "You do not have sufficient permissions to perform this action");
+        appAssert(isOwner, FORBIDDEN, "You do not have sufficient permissions to perform this action");
 
         Object.assign(workspace, payload);
         await workspace.save();
@@ -109,8 +115,8 @@ export const WorkspaceService = {
 
         const member = await WorkspaceMemberModel.findOne({ userId, workspaceId }).populate("role");
         const isOwner = workspace.owner.toString() === userId;
-        const isAdmin = member?.role?.name === "OWNER";
-        appAssert(isOwner || isAdmin, FORBIDDEN, "Nie masz uprawnień do usunięcia użytkownika z tej kolekcji");
+
+        appAssert(isOwner, FORBIDDEN, "Nie masz uprawnień do usunięcia użytkownika z tej kolekcji");
 
         const memberToRemove = await WorkspaceMemberModel.findById(memberId);
         appAssert(
@@ -119,7 +125,6 @@ export const WorkspaceService = {
             "Użytkownik nie należy do wybranej kolekcji"
         );
 
-        appAssert(memberToRemove.role.name !== "OWNER", FORBIDDEN, "Brak uprawnień do wykonania tej operacji");
         appAssert(memberToRemove.userId.toString() !== userId, FORBIDDEN, "Brak uprawnień do wykonania tej operacji");
 
         await WorkspaceMemberModel.deleteOne({ _id: memberId });

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import { tagRoutes } from "./features/tag/tag.route";
 import { userRoutes } from "./features/user/user.route";
 import { workspaceArticleRoutes } from "./features/workspace-article/workspace-article.route";
 import { workspaceFolderRoutes } from "./features/workspace-folder/workspace-folder.routes";
+import { workspaceMemberRoutes } from "./features/workspace-member/workspace-member.routes";
 import { workspaceRoutes } from "./features/workspace/workspace.route";
 import authenticate from "./middleware/authenticate";
 import errorHandler from "./middleware/errorHandlers";
@@ -107,6 +108,7 @@ app.use("/attachments", authenticate, attachmentRoutes);
 app.use("/workspaces", authenticate, workspaceRoutes);
 app.use("/workspace-folders", authenticate, workspaceFolderRoutes);
 app.use("/workspace-articles", authenticate, workspaceArticleRoutes);
+app.use("/workspace-members", authenticate, workspaceMemberRoutes);
 
 const uploadsPath = path.resolve("/app/uploads");
 app.use(


### PR DESCRIPTION
- Removed role from WorkspaceMember model,
- Updated findMembers and related endpoints to use permissions,
- Added PATCH /workspace-members/:memberId/permissions endpoint,
- Adjusted services and controllers for permission-based logic